### PR TITLE
Fix heroku build hanging in the npm build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dev-build": "webpack --progress -d --config webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "webpack --progress -d --config webpack.config.js --watch",
-    "heroku-postbuild": "webpack --progress -d --config webpack.config.js --watch"
+    "heroku-postbuild": "webpack --progress -d --config webpack.config.js"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",


### PR DESCRIPTION
--watch in heroku-postbuild script keeps the script from terminating which blocks the rest of the Heroku build. Removing it fixes that.